### PR TITLE
Updated initialization of PCA9536 in setup

### DIFF
--- a/Particle/PCA9536_R21.ino
+++ b/Particle/PCA9536_R21.ino
@@ -14,19 +14,22 @@ void setup()
 {
   // Set variable
   Particle.variable("i2cdevice", "PCA9536_R21");
-  
-  // Initialise I2C communication
-  Wire.begin();
   // Initialise Serial Communication, set baud rate = 9600
   Serial.begin(9600);
+  // Initialise I²C communication
+  Wire.begin();
 
-  // Start I2C transmission
+  // Turn off all channels prior to initialization of chip so relays do not turn on after initializing channels to outputs.
+  Wire.beginTransmission(Addr);
+  Wire.write(0x01);
+  Wire.write(0x00);
+  Wire.endTransmission();
+
   Wire.beginTransmission(Addr);
   // Select configuration register
   Wire.write(0x03);
   // Set all pins as OUTPUT
   Wire.write(0x00);
-  // Stop I2C transmission
   Wire.endTransmission();
   delay(300);
 }


### PR DESCRIPTION
Updated to set all channels to 0/off prior to setting channels to outputs.  By default on power up all channels are set to high so after channels are set to outputs they turn on, setting channels low prior to setting to outputs prevents relays from turning on after set to outputs.